### PR TITLE
Matstream typedef added

### DIFF
--- a/src/packagedmaterial.cc
+++ b/src/packagedmaterial.cc
@@ -1,10 +1,5 @@
 #include "packagedmaterial.h"
 
-#include <math.h>
-
-#include "comp_math.h"
-#include "context.h"
-#include "decayer.h"
 #include "error.h"
 #include "logger.h"
 
@@ -12,228 +7,76 @@ namespace cyclus {
 
 const ResourceType PackagedMaterial::kType = "PackagedMaterial";
 
-PackagedMaterial::~PackagedMaterial() {}
+std::map<std::string, int> PackagedMaterial::qualids_;
+int PackagedMaterial::next_qualid_ = 1;
 
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 PackagedMaterial::Ptr PackagedMaterial::Create(Agent* creator, double quantity,
-                               Composition::Ptr c) {
-  PackagedMaterial::Ptr m(new PackagedMaterial(creator->context(), quantity, c));
-  m->tracker_.Create(creator);
-  return m;
+                             std::string quality) {
+  if (qualids_.count(quality) == 0) {
+    qualids_[quality] = next_qualid_++;
+    creator->context()->NewDatum("PackagedMaterials")
+        ->AddVal("QualId", qualids_[quality])
+        ->AddVal("Quality", quality)
+        ->Record();
+  }
+
+  // the next lines must come after qual id setting
+  PackagedMaterial::Ptr r(new PackagedMaterial(creator->context(), quantity, quality));
+  r->tracker_.Create(creator);
+  return r;
 }
 
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 PackagedMaterial::Ptr PackagedMaterial::CreateUntracked(double quantity,
-                                        Composition::Ptr c) {
-  PackagedMaterial::Ptr m(new PackagedMaterial(NULL, quantity, c));
-  return m;
+                                      std::string quality) {
+  PackagedMaterial::Ptr r(new PackagedMaterial(NULL, quantity, quality));
+  r->tracker_.DontTrack();
+  return r;
 }
 
-int PackagedMaterial::qual_id() const {
-  return comp_->id();
-}
-
-const ResourceType PackagedMaterial::type() const {
-  return PackagedMaterial::kType;
-}
-
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Resource::Ptr PackagedMaterial::Clone() const {
-  PackagedMaterial* m = new PackagedMaterial(*this);
-  Resource::Ptr c(m);
-  m->tracker_.DontTrack();
+  PackagedMaterial* g = new PackagedMaterial(*this);
+  Resource::Ptr c = Resource::Ptr(g);
+  g->tracker_.DontTrack();
   return c;
 }
 
-void PackagedMaterial::Record(Context* ctx) const {
-  // Note that no time field is needed because the resource ID changes
-  // every time the resource changes - state_id by itself is already unique.
-  ctx_->NewDatum("PackagedMaterialInfo")
-      ->AddVal("ResourceId", state_id())
-      ->AddVal("PrevDecayTime", prev_decay_time_)
-      ->Record();
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void PackagedMaterial::Absorb(PackagedMaterial::Ptr other) {
+  if (other->quality() != quality()) {
+    throw ValueError("incompatible resource types.");
+  }
+  quantity_ += other->quantity();
+  other->quantity_ = 0;
 
-  comp_->Record(ctx);
+  tracker_.Absorb(&other->tracker_);
 }
 
-std::string PackagedMaterial::units() const {
-  return "kg";
-}
-
-double PackagedMaterial::quantity() const {
-  return qty_;
-}
-
-Resource::Ptr PackagedMaterial::ExtractRes(double qty) {
-  return boost::static_pointer_cast<Resource>(ExtractQty(qty));
-}
-
-PackagedMaterial::Ptr PackagedMaterial::ExtractQty(double qty) {
-  return ExtractComp(qty, comp_);
-}
-
-PackagedMaterial::Ptr PackagedMaterial::ExtractComp(double qty, Composition::Ptr c,
-                                    double threshold) {
-  if (qty_ < qty) {
-    throw ValueError("mass extraction causes negative quantity");
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+PackagedMaterial::Ptr PackagedMaterial::Extract(double quantity) {
+  if (quantity > quantity_) {
+    throw ValueError("Attempted to extract more quantity than exists.");
   }
 
-  // TODO: decide if ExtractComp should force lazy-decay by calling comp()
-  if (comp_ != c) {
-    CompMap v(comp_->mass());
-    compmath::Normalize(&v, qty_);
-    CompMap otherv(c->mass());
-    compmath::Normalize(&otherv, qty);
-    CompMap newv = compmath::Sub(v, otherv);
-    compmath::ApplyThreshold(&newv, threshold);
-    comp_ = Composition::CreateFromMass(newv);
-  }
+  quantity_ -= quantity;
 
-  qty_ -= qty;
-
-  PackagedMaterial::Ptr other(new PackagedMaterial(ctx_, qty, c));
-
-  // Decay called on the extracted packagedmaterial should have the same dt as for
-  // this packagedmaterial regardless of composition.
-  other->prev_decay_time_ = prev_decay_time_;
-
+  PackagedMaterial::Ptr other(new PackagedMaterial(ctx_, quantity, quality_));
   tracker_.Extract(&other->tracker_);
-
   return other;
 }
 
-void PackagedMaterial::Absorb(PackagedMaterial::Ptr mat) {
-  // these calls force lazy evaluation if in lazy decay mode
-  Composition::Ptr c0 = comp();
-  Composition::Ptr c1 = mat->comp();
-
-  if (c0 != c1) {
-    CompMap v(c0->mass());
-    compmath::Normalize(&v, qty_);
-    CompMap otherv(c1->mass());
-    compmath::Normalize(&otherv, mat->qty_);
-    comp_ = Composition::CreateFromMass(compmath::Add(v, otherv));
-  }
-
-  // Set the decay time to the value of the packagedmaterial that had the larger
-  // quantity.  This helps avoid inheriting erroneous prev decay times if, for
-  // example, you absorb a packagedmaterial into a zero-quantity packagedmaterial that had a
-  // prev decay time prior to the current simulation time step.
-  if (qty_ < mat->qty_) {
-    prev_decay_time_ = mat->prev_decay_time_;
-  }
-
-  qty_ += mat->qty_;
-  mat->qty_ = 0;
-  tracker_.Absorb(&mat->tracker_);
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Resource::Ptr PackagedMaterial::ExtractRes(double qty) {
+  return boost::static_pointer_cast<Resource>(Extract(qty));
 }
 
-void PackagedMaterial::Transmute(Composition::Ptr c) {
-  comp_ = c;
-  tracker_.Modify();
-
-  // Presumably the user has chosen the new composition to be accurate for
-  // the current simulation time.  The next call to decay should not include
-  // accumulated decay delta t from a composition that no longer exists in
-  // this packagedmaterial.  This ---------+ condition allows testing to work.
-  //                               |
-  //                               |
-  //                               V
-  if (ctx_ != NULL && ctx_->time() > prev_decay_time_) {
-    prev_decay_time_ = ctx_->time();
-  }
-}
-
-void PackagedMaterial::Decay(int curr_time) {
-  if (ctx_ != NULL && ctx_->sim_info().decay == "never") {
-    return;
-  } else if (curr_time < 0 && ctx_ == NULL) {
-    throw ValueError("decay cannot use default time with NULL context");
-  }
-
-  if (curr_time < 0) {
-    curr_time = ctx_->time();
-  }
-
-  int dt = curr_time - prev_decay_time_;
-  if (dt == 0) {
-    return;
-  }
-
-  double eps = 1e-3;
-  const CompMap c = comp_->atom();
-
-  // If composition has too many nuclides (i.e. > 100), it is cheaper to
-  // just do the decay rather than check all the decay constants.
-  bool decay = c.size() > 100;
-
-  uint64_t secs_per_timestep = kDefaultTimeStepDur;
-  if (ctx_ != NULL) {
-    secs_per_timestep = ctx_->sim_info().dt;
-  }
-
-  if (!decay) {
-    // Only do the decay calc if one of the nuclides would change in number
-    // density more than fraction eps.
-    // i.e. decay if   (1 - eps) > exp(-lambda*dt)
-    CompMap::const_reverse_iterator it;
-    for (it = c.rbegin(); it != c.rend(); ++it) {
-      int nuc = it->first;
-      double lambda_timesteps = pyne::decay_const(nuc) * static_cast<double>(secs_per_timestep);
-      double change = 1.0 - std::exp(-lambda_timesteps * static_cast<double>(dt));
-      if (change >= eps) {
-        decay = true;
-        break;
-      }
-    }
-    if (!decay) {
-      return;
-    }
-  }
-
-  prev_decay_time_ = curr_time; // this must go before Transmute call
-  Composition::Ptr decayed = comp_->Decay(dt, secs_per_timestep);
-  Transmute(decayed);
-}
-
-double PackagedMaterial::DecayHeat() {
-  double decay_heat = 0.;
-  // Pyne decay heat operates with grams, cyclus generally in kilograms.
-  pyne::Material p_map = pyne::Material(comp_->mass(), qty_ * 1000);
-  std::map<int, double> dec_heat = p_map.decay_heat();
-  for (auto nuc : dec_heat) {
-    if (!std::isnan(nuc.second)) {
-      decay_heat += nuc.second;
-    }
-  }
-  return decay_heat;
-}
-
-Composition::Ptr PackagedMaterial::comp() const {
-  throw Error("comp() const is deprecated - use non-const comp() function."
-              " Recompilation should fix the problem.");
-}
-
-Composition::Ptr PackagedMaterial::comp() {
-  if (ctx_ != NULL && ctx_->sim_info().decay == "lazy") {
-    Decay(-1);
-  }
-  return comp_;
-}
-
-PackagedMaterial::PackagedMaterial(Context* ctx, double quantity, Composition::Ptr c)
-    : qty_(quantity),
-      comp_(c),
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+PackagedMaterial::PackagedMaterial(Context* ctx, double quantity, std::string quality)
+    : quality_(quality),
+      quantity_(quantity),
       tracker_(ctx, this),
-      ctx_(ctx),
-      prev_decay_time_(0) {
-  if (ctx != NULL) {
-    prev_decay_time_ = ctx->time();
-  } else {
-    tracker_.DontTrack();
-  }
-}
-
-PackagedMaterial::Ptr NewBlankPackagedMaterial(double quantity) {
-  Composition::Ptr comp = Composition::CreateFromMass(CompMap());
-  return PackagedMaterial::CreateUntracked(quantity, comp);
-}
+      ctx_(ctx) {}
 
 }  // namespace cyclus

--- a/src/packagedmaterial.cc
+++ b/src/packagedmaterial.cc
@@ -7,12 +7,12 @@ namespace cyclus {
 
 const ResourceType PackagedMaterial::kType = "PackagedMaterial";
 
-std::map<std::string, int> PackagedMaterial::qualids_;
+std::map<PackagedMaterial::matstream, int> PackagedMaterial::qualids_;
 int PackagedMaterial::next_qualid_ = 1;
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 PackagedMaterial::Ptr PackagedMaterial::Create(Agent* creator, double quantity,
-                             std::string quality) {
+                             PackagedMaterial::matstream quality) {
   if (qualids_.count(quality) == 0) {
     qualids_[quality] = next_qualid_++;
     creator->context()->NewDatum("PackagedMaterials")
@@ -28,12 +28,14 @@ PackagedMaterial::Ptr PackagedMaterial::Create(Agent* creator, double quantity,
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
 PackagedMaterial::Ptr PackagedMaterial::CreateUntracked(double quantity,
-                                      std::string quality) {
+                                      PackagedMaterial::matstream quality) {
   PackagedMaterial::Ptr r(new PackagedMaterial(NULL, quantity, quality));
   r->tracker_.DontTrack();
   return r;
 }
+
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Resource::Ptr PackagedMaterial::Clone() const {
@@ -73,7 +75,7 @@ Resource::Ptr PackagedMaterial::ExtractRes(double qty) {
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-PackagedMaterial::PackagedMaterial(Context* ctx, double quantity, std::string quality)
+PackagedMaterial::PackagedMaterial(Context* ctx, double quantity, PackagedMaterial::matstream quality)
     : quality_(quality),
       quantity_(quantity),
       tracker_(ctx, this),

--- a/src/packagedmaterial.h
+++ b/src/packagedmaterial.h
@@ -6,6 +6,7 @@
 #include "context.h"
 #include "resource.h"
 #include "res_tracker.h"
+#include "material.h"
 
 class SimInitTest;
 
@@ -20,19 +21,19 @@ class PackagedMaterial : public Resource {
   friend class ::SimInitTest;
 
  public:
-  typedef
-  boost::shared_ptr<PackagedMaterial> Ptr;
+  typedef boost::shared_ptr<PackagedMaterial> Ptr;
+  typedef std::vector<Material::Ptr> matstream;
   static const ResourceType kType;
 
   /// Creates a new product that is "live" and tracked. creator is a
   /// pointer to the agent creating the resource (usually will be the caller's
   /// "this" pointer). All future output data recorded will be done using the
   /// creator's context.
-  static Ptr Create(Agent* creator, double quantity, std::string quality);
+  static Ptr Create(Agent* creator, double quantity, matstream quality);
 
   /// Creates a new product that does not actually exist as part of
   /// the simulation and is untracked.
-  static Ptr CreateUntracked(double quantity, std::string quality);
+  static Ptr CreateUntracked(double quantity, matstream quality);
 
   /// Returns 0 (for now).
   virtual int qual_id() const {
@@ -55,7 +56,7 @@ class PackagedMaterial : public Resource {
   }
 
   /// Returns the quality of this resource (e.g. bananas, human labor, water, etc.).
-  virtual const std::string& quality() const {
+  virtual const matstream& quality() const {
     return quality_;
   }
 
@@ -75,14 +76,14 @@ class PackagedMaterial : public Resource {
   /// @param ctx the simulation context
   /// @param quantity is a double indicating the quantity
   /// @param quality the resource quality
-  PackagedMaterial(Context* ctx, double quantity, std::string quality);
+  PackagedMaterial(Context* ctx, double quantity, matstream quality);
 
   // map<quality, quality_id>
-  static std::map<std::string, int> qualids_;
+  static std::map<matstream, int> qualids_;
   static int next_qualid_;
 
   Context* ctx_;
-  std::string quality_;
+  matstream quality_;
   double quantity_;
   ResTracker tracker_;
 };

--- a/src/packagedmaterial.h
+++ b/src/packagedmaterial.h
@@ -1,166 +1,91 @@
 #ifndef CYCLUS_SRC_PACKAGED_MATERIAL_H_
 #define CYCLUS_SRC_PACKAGED_MATERIAL_H_
 
-#include <list>
 #include <boost/shared_ptr.hpp>
 
-#include "composition.h"
-#include "cyc_limits.h"
+#include "context.h"
 #include "resource.h"
 #include "res_tracker.h"
 
+class SimInitTest;
+
 namespace cyclus {
 
-class Context;
-
-/// The packagedmaterial class is primarily responsible for enabling basic packagedmaterial
-/// manipulation while helping enforce mass conservation.  It also provides the
-/// ability to easily decay a packagedmaterial up to the current simulation time; it
-/// does not perform any decay related logic itself.
-///
-/// There are four basic operations that can be performed on packagedmaterials: create,
-/// transmute (change packagedmaterial composition - e.g. fission by reactor), absorb
-/// (combine packagedmaterials), extract (split a packagedmaterial). All packagedmaterial
-/// handling/manipulation will be performed using these operations - and all
-/// operations performed will be tracked and recorded. Usage examples:
-///
-/// * A mining facility that "creates" new packagedmaterial
-///
-///   @code
-///   Composition::Ptr nat_u = ...
-///   double qty = 10.0;
-///
-///   PackagedMaterial::Ptr m = PackagedMaterial::Create(qty, nat_u, ctx);
-///   @endcode
-///
-/// * A conversion facility mixing uranium and flourine:
-///
-///   @code
-///   PackagedMaterial::Ptr uf6 = uranium_buf.Pop();
-///   PackagedMaterial::Ptr f = flourine_buf.Pop();
-///
-///   uf6.Absorb(f);
-///   @endcode
-///
-/// * A reactor transmuting fuel:
-///
-///   @code
-///   Composition::Ptr burned_comp = ... // fancy code to calculate burned nuclides
-///   PackagedMaterial::Ptr assembly = core_fuel.Pop();
-///
-///   assembly.Transmute(burned_comp);
-///   @endcode
-///
-/// * A separations plant extracting stuff from spent fuel:
-///
-///   @code
-///   Composition::Ptr comp = ... // fancy code to calculate extracted nuclides
-///   Material::Ptr bucket = spent_fuel.Pop();
-///   double qty = 3.0;
-///
-///   PackagedMaterial::Ptr mox = bucket.ExtractComp(qty, comp);
-///   @endcode
-///
-class PackagedMaterial: public Resource {
+/// A PackagedMaterial is a general type of resource in the Cyclus simulation,
+/// and is a catch-all for non-standard resources.  It implements the Resource
+/// class interface in a simple way usable for things such as: bananas,
+/// man-hours, water, buying power, etc.
+class PackagedMaterial : public Resource {
   friend class SimInit;
+  friend class ::SimInitTest;
 
  public:
-  typedef boost::shared_ptr<PackagedMaterial> Ptr;
+  typedef
+  boost::shared_ptr<PackagedMaterial> Ptr;
   static const ResourceType kType;
 
-  virtual ~PackagedMaterial();
-
-  /// Creates a new packagedmaterial resource that is "live" and tracked. creator is a
+  /// Creates a new product that is "live" and tracked. creator is a
   /// pointer to the agent creating the resource (usually will be the caller's
   /// "this" pointer). All future output data recorded will be done using the
   /// creator's context.
-  static Ptr Create(Agent* creator, double quantity, Composition::Ptr c);
+  static Ptr Create(Agent* creator, double quantity, std::string quality);
 
-  /// Creates a new packagedmaterial resource that does not actually exist as part of
+  /// Creates a new product that does not actually exist as part of
   /// the simulation and is untracked.
-  static Ptr CreateUntracked(double quantity, Composition::Ptr c);
+  static Ptr CreateUntracked(double quantity, std::string quality);
 
-  /// Returns the id of the packagedmaterial's internal nuclide composition.
-  virtual int qual_id() const;
+  /// Returns 0 (for now).
+  virtual int qual_id() const {
+    return qualids_[quality_];
+  }
 
   /// Returns PackagedMaterial::kType.
-  virtual const ResourceType type() const;
+  virtual const ResourceType type() const {
+    return kType;
+  }
 
-  /// Creates an untracked copy of this packagedmaterial object.
   virtual Resource::Ptr Clone() const;
 
-  /// Records the internal nuclide composition of this resource.
-  virtual void Record(Context* ctx) const;
+  virtual void Record(Context* ctx) const {}
 
-  /// Returns "kg"
-  virtual std::string units() const;
+  virtual std::string units() const { return "NONE"; }
 
-  /// Returns the mass of this packagedmaterial in kg.
-  virtual double quantity() const;
+  virtual double quantity() const {
+    return quantity_;
+  }
 
-  virtual Resource::Ptr ExtractRes(double qty);
+  /// Returns the quality of this resource (e.g. bananas, human labor, water, etc.).
+  virtual const std::string& quality() const {
+    return quality_;
+  }
 
-  /// Same as ExtractComp with c = this->comp().
-  Ptr ExtractQty(double qty);
+  virtual Resource::Ptr ExtractRes(double quantity);
 
-  /// Creates a new packagedmaterial by extracting from this one.
+  /// Extracts the specified mass from this resource and returns it as a
+  /// new product object with the same quality/type.
   ///
-  /// @param qty the mass quantity to extract
-  /// @param c the composition the extracted/returned packagedmaterial
-  /// @param threshold an absolute mass cutoff below which constituent nuclide
-  /// quantities of the remaining unextracted packagedmaterial are set to zero.
-  /// @return a new packagedmaterial with quantity qty and composition c
-  Ptr ExtractComp(double qty, Composition::Ptr c,
-                  double threshold = eps_rsrc());
+  /// @throws ValueError tried to extract more than exists.
+  PackagedMaterial::Ptr Extract(double quantity);
 
-  /// Combines packagedmaterial mat with this one.  mat's quantity becomes zero.
-  void Absorb(Ptr mat);
-
-  /// Changes the packagedmaterial's composition to c without changing its mass.  Use
-  /// this method for things like converting fresh to spent fuel via burning in
-  /// a reactor.
-  void Transmute(Composition::Ptr c);
-
-  /// Updates the packagedmaterial's composition by performing a decay calculation.
-  /// This is a special case of Transmute where the new composition is
-  /// calculated automatically.  The time delta is calculated as the difference
-  /// between curr_time and the last time the packagedmaterial's composition was
-  /// updated with a decay calculation (i.e. prev_decay_time).  This may or may
-  /// not result in an updated packagedmaterial composition.  Does nothing if the
-  /// simulation decay mode is set to "never" or none of the nuclides' decay
-  /// constants are significant with respect to the time delta.
-  void Decay(int curr_time);
-
-  /// Returns the last time step on which a decay calculation was performed
-  /// for the packagedmaterial.  This is not necessarily synonymous with the last time
-  /// step the packagedmaterial's Decay function was called.
-  int prev_decay_time() { return prev_decay_time_; }
-
-  /// Returns a double with the decay heat of the packagedmaterial in units of
-  /// W/kg.
-  double DecayHeat();
-
-  /// Returns the nuclide composition of this packagedmaterial.
-  Composition::Ptr comp();
-
-  /// DEPRECATED - use non-const comp() function.
-  Composition::Ptr comp() const;
-
- protected:
-  PackagedMaterial(Context* ctx, double quantity, Composition::Ptr c);
+  /// Absorbs the contents of the given 'other' resource into this resource.
+  /// @throws ValueError 'other' resource is of different quality
+  void Absorb(PackagedMaterial::Ptr other);
 
  private:
+  /// @param ctx the simulation context
+  /// @param quantity is a double indicating the quantity
+  /// @param quality the resource quality
+  PackagedMaterial(Context* ctx, double quantity, std::string quality);
+
+  // map<quality, quality_id>
+  static std::map<std::string, int> qualids_;
+  static int next_qualid_;
+
   Context* ctx_;
-  double qty_;
-  Composition::Ptr comp_;
-  int prev_decay_time_;
+  std::string quality_;
+  double quantity_;
   ResTracker tracker_;
 };
-
-/// Creates and returns a new packagedmaterial with the specified quantity and a
-/// default, meaningless composition.  This is intended only for testing
-/// purposes.
-PackagedMaterial::Ptr NewBlankPackagedMaterial(double qty);
 
 }  // namespace cyclus
 

--- a/tests/resource_tests.cc
+++ b/tests/resource_tests.cc
@@ -30,10 +30,14 @@ class ResourceTest : public ::testing::Test {
 
     m1 = Material::Create(dummy, 3, c);
     m2 = Material::Create(dummy, 7, c);
-    pm1 = PackagedMaterial::Create(dummy, 3, c);
-    pm2 = PackagedMaterial::Create(dummy, 7, c);
     p1 = Product::Create(dummy, 3, "bananas");
     p2 = Product::Create(dummy, 7, "bananas");
+
+    cyclus::PackagedMaterial::matstream ms;
+    ms.push_back(m1);
+    ms.push_back(m2);
+    pm1 = PackagedMaterial::Create(dummy, 3, ms);
+    pm2 = PackagedMaterial::Create(dummy, 7, ms);
   }
 
   virtual void TearDown() {
@@ -78,6 +82,7 @@ TEST_F(ResourceTest, MaterialExtractGraphid) {
   EXPECT_NE(m1->state_id(), m3->state_id());
 }
 
+
 TEST_F(ResourceTest, PackagedMaterialAbsorbTrackid) {
   int obj_id = pm1->obj_id();
   pm1->Absorb(pm2);
@@ -92,18 +97,19 @@ TEST_F(ResourceTest, PackagedMaterialAbsorbGraphid) {
 
 TEST_F(ResourceTest, PackagedMaterialExtractTrackid) {
   int obj_id = pm1->obj_id();
-  PackagedMaterial::Ptr pm3 = pm1->ExtractQty(2);
+  PackagedMaterial::Ptr pm3 = pm1->Extract(2);
   EXPECT_EQ(obj_id, pm1->obj_id());
   EXPECT_LT(obj_id, pm3->obj_id());
 }
 
 TEST_F(ResourceTest, PackagedMaterialExtractGraphid) {
   int state_id = pm1->state_id();
-  PackagedMaterial::Ptr pm3 = pm1->ExtractQty(2);
+  PackagedMaterial::Ptr pm3 = pm1->Extract(2);
   EXPECT_LT(state_id, pm1->state_id());
   EXPECT_LT(state_id, pm3->state_id());
   EXPECT_NE(pm1->state_id(), pm3->state_id());
 }
+
 
 TEST_F(ResourceTest, ProductAbsorbTrackid) {
   int obj_id = p1->obj_id();


### PR DESCRIPTION
In this PR: 
1) A vector of Material::Ptr objects variable type is added to packagedmaterial.h and cc 
2) resource_tests.cc is updated to test the new variable type 